### PR TITLE
Endpoint watcher dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # RiemannProxy
 
-**TODO: Add description**
+The main motivation behind writing a Riemann Proxy relies in the fact that handling lots of metrics and calculations can lead in asymetric topology of several Riemann servers scattering and gathering subsets of information to take different responsibilities over each subset (ie.: making partials, moving averages, alerting, etc.). Also, there are the following motivations behind Riemann-Proxy:
+
+* Single and symmetric configuration
+* Automatically ring-failover on Riemann servers
+* Put into practice various Erlang VM and Elixir stuff in a real production environment
 
 ## Installation
 

--- a/lib/riemann_proxy.ex
+++ b/lib/riemann_proxy.ex
@@ -4,9 +4,11 @@ defmodule RiemannProxy do
   def start(_type, _args) do
     import Supervisor.Spec
 
+    :mnesia.start()
+
     children = [
       supervisor(Task.Supervisor, [[name: RiemannProxy.TaskSupervisor]]),
-      worker(Task, [RiemannProxy.Server, :accept, [5555]])
+      worker(Task, [RiemannProxy.Server, :accept, [6782]])
     ]
 
     opts = [strategy: :one_for_one, name: RiemannProxy.Supervisor]

--- a/lib/riemann_proxy/endpoint.ex
+++ b/lib/riemann_proxy/endpoint.ex
@@ -1,0 +1,36 @@
+defmodule RiemannProxy.Endpoint do
+  require Record
+  Record.defrecord :endpoint, [:idx, :host, port: 5555, transport: "tcp"]
+
+  def create(idx, host, port, transport) do
+    f = fn ->
+      :mnesia.write(
+        :endpoints,
+        endpoint(
+          idx: idx,
+          host: host,
+          port: port,
+          transport: transport
+        ),
+        :write
+      )
+    end
+    :mnesia.activity(:transaction, f)
+  end
+
+  def read(idx) do
+    f = fn ->
+      :mnesia.read(:endpoints, idx)
+    end
+    [data|_] = :mnesia.activity(:transaction, f)
+    endpoint(data)
+  end
+
+  def read_all do
+    # match_spec generated with :ets.fun2ms(fn(x) -> x end)
+    f = fn ->
+      :mnesia.select(:endpoints, [{:"$1", [], [:"$1"]}])
+    end
+    :mnesia.activity(:transaction, f)
+  end
+end

--- a/lib/riemann_proxy/endpoint.ex
+++ b/lib/riemann_proxy/endpoint.ex
@@ -32,5 +32,6 @@ defmodule RiemannProxy.Endpoint do
       :mnesia.select(:endpoints, [{:"$1", [], [:"$1"]}])
     end
     :mnesia.activity(:transaction, f)
+    |> Enum.map(fn(data) -> endpoint(data) end)
   end
 end

--- a/lib/riemann_proxy/endpoint_dispatcher.ex
+++ b/lib/riemann_proxy/endpoint_dispatcher.ex
@@ -1,0 +1,49 @@
+defmodule RiemannProxy.EndpointDispatcher do
+  require Record
+  Record.defrecord :endpoint_dispatcher, [:idx, :pid]
+
+  use GenServer
+
+  def init({host, port}) do
+    {:ok, socket} = connect(host, port)
+    IO.puts "endpoint dispatcher for #{inspect {host, port}} created @ #{inspect self}"
+    {:ok, socket}
+  end
+
+  defp connect(host, port) do
+    :gen_tcp.connect(host, port, [:binary, packet: 4, active: false, send_timeout: 2000], 2000)
+    # {:error, _reason}
+  end
+
+  def handle_cast({:dispatch, msg}, socket) do
+    IO.puts "dispatch: #{inspect msg} (#{inspect socket}) @ #{inspect self}"
+    :ok = :gen_tcp.send(socket, msg)
+    {:ok, _resp} = :gen_tcp.recv(socket, 0)
+
+    {:noreply, socket}
+  end
+
+  def create(idx, pid) do
+    f = fn ->
+      :mnesia.write(
+        :endpoint_dispatchers,
+        endpoint_dispatcher(
+          idx: idx,
+          pid: pid
+        ),
+        :write
+      )
+    end
+    :mnesia.activity(:transaction, f)
+  end
+
+  def read(idx) do
+    f = fn ->
+      :mnesia.read(:endpoint_dispatchers, idx)
+    end
+    case List.first(:mnesia.activity(:transaction, f)) do
+      nil -> nil
+      data -> endpoint_dispatcher(data)
+    end
+  end
+end

--- a/lib/riemann_proxy/endpoint_watcher.ex
+++ b/lib/riemann_proxy/endpoint_watcher.ex
@@ -1,0 +1,49 @@
+defmodule RiemannProxy.EndpointWatcher do
+  use GenServer
+  require RiemannProxy.Endpoint
+
+  def start_link do
+    GenServer.start_link(__MODULE__, {}, [{:name, {:local, __MODULE__}}])
+  end
+
+  def init({}) do
+    prefill
+    subscribe
+    {:ok, {}}
+  end
+
+  defp prefill do
+    RiemannProxy.Endpoint.read_all
+    |> Enum.each(fn(e) -> spin_endpoint(e) end)
+  end
+
+  defp subscribe do
+    :mnesia.subscribe({:table, :endpoints, :simple})
+  end
+
+  defp mnesia_record_to_endpoint(record) do
+    Tuple.delete_at(record,0)
+    |> Tuple.insert_at(0, :endpoint)
+    |> RiemannProxy.Endpoint.endpoint
+  end
+
+  defp spin_endpoint(endpoint) do
+    {:ok, pid} = GenServer.start(RiemannProxy.EndpointDispatcher, {endpoint[:host], endpoint[:port]}, [])
+    RiemannProxy.EndpointDispatcher.create(endpoint[:idx], pid)
+  end
+
+  def handle_info({:mnesia_table_event, {:write, record, _d}}, state) do
+    record
+    |> mnesia_record_to_endpoint
+    |> spin_endpoint
+
+    {:noreply, state}
+  end
+
+  def handle_info(msg, state) do
+    IO.puts("mnesia change: #{inspect msg}")
+    # GenServer.call(__MODULE__, {:route, {payload, routing_key}})
+
+    {:noreply, state}
+  end
+end

--- a/lib/riemann_proxy/mnesia.ex
+++ b/lib/riemann_proxy/mnesia.ex
@@ -1,0 +1,19 @@
+defmodule RiemannProxy.Mnesia do
+  def setup do
+    :ok = :mnesia.create_schema([node()])
+    :mnesia.start()
+
+    # :application.set_env(:mnesia, :dir, 'priv_dir')
+
+    :mnesia.create_table(:endpoints, [
+      {:attributes, [:idx, :host, :port, :transport]},
+      {:type, :ordered_set},
+      {:record_name, :endpoint},
+      {:disc_copies, [node()]}
+    ])
+  end
+
+  def multi_stop do
+    :rpc.multicall([node()], :application, :stop, [:mnesia])
+  end
+end

--- a/lib/riemann_proxy/mnesia.ex
+++ b/lib/riemann_proxy/mnesia.ex
@@ -1,6 +1,7 @@
 defmodule RiemannProxy.Mnesia do
   def setup do
-    :ok = :mnesia.create_schema([node()])
+    nodes = Node.list ++ [node()]
+    :ok = :mnesia.create_schema(nodes)
     :mnesia.start()
 
     # :application.set_env(:mnesia, :dir, 'priv_dir')
@@ -9,7 +10,14 @@ defmodule RiemannProxy.Mnesia do
       {:attributes, [:idx, :host, :port, :transport]},
       {:type, :ordered_set},
       {:record_name, :endpoint},
-      {:disc_copies, [node()]}
+      {:disc_copies, nodes}
+    ])
+
+    :mnesia.create_table(:endpoint_dispatchers, [
+      {:attributes, [:idx, :pid]},
+      {:type, :set},
+      {:record_name, :endpoint_dispatcher},
+      {:local_content, true}
     ])
   end
 

--- a/lib/riemann_proxy/ping.ex
+++ b/lib/riemann_proxy/ping.ex
@@ -8,10 +8,20 @@ defmodule RiemannProxy.Ping do
   defp try_send({:ok, socket}) do
     query = RiemannProxy.Proto.Query.new(string: 'service = "riemann.ping"')
     msg = RiemannProxy.Proto.Msg.encode(RiemannProxy.Proto.Msg.new(query: query))
+    # msg = RiemannProxy.Proto.Msg.encode(RiemannProxy.Proto.Msg.new(events: [RiemannProxy.Proto.Event.new(attributes: [], description: nil, service: "test", host: "cuzco", metric_sint64: 1)]))
     :ok = :gen_tcp.send(socket, msg)
     case :gen_tcp.recv(socket, 0) do
       {:ok, _resp} -> true # Proto.Msg.decode(resp)
       _ -> false
     end
   end
+
+  # def benchmark(host) do
+  #   {:ok, socket} = :gen_tcp.connect(host, 6782, [:binary, packet: 4, active: false, send_timeout: 2000], 2000)
+  #   IO.puts(inspect :calendar.local_time())
+  #   for n <- 1..10000 do
+  #     try_send({:ok, socket})
+  #   end
+  #   IO.puts(inspect :calendar.local_time())
+  # end
 end

--- a/lib/riemann_proxy/router.ex
+++ b/lib/riemann_proxy/router.ex
@@ -1,0 +1,21 @@
+defmodule RiemannProxy.Router do
+  require RiemannProxy.Endpoint
+
+  def fake_route(msg) do
+    {host, port} = select_host
+    :gen_tcp.connect(host, port, [:binary, packet: 4, active: false, send_timeout: 2000], 2000)
+    |> forward(msg)
+  end
+
+  defp forward({:error, _reason}, _msg), do: false
+  defp forward({:ok, socket}, msg) do
+    :ok = :gen_tcp.send(socket, msg)
+    {:ok, _resp} = :gen_tcp.recv(socket, 0)
+  end
+
+  defp select_host do
+    [data|_] = RiemannProxy.Endpoint.read_all
+    endpoint = RiemannProxy.Endpoint.endpoint(data)
+    {endpoint[:host], endpoint[:port]}
+  end
+end

--- a/lib/riemann_proxy/server.ex
+++ b/lib/riemann_proxy/server.ex
@@ -23,8 +23,14 @@ defmodule RiemannProxy.Server do
 
   defp read_line(socket) do
     {:ok, data} = :gen_tcp.recv(socket, 0)
-    IO.puts "Forwarding message: #{inspect RiemannProxy.Proto.Msg.decode(data)}"
-    RiemannProxy.Router.fake_route(data)
+    spawn(fn -> IO.puts("Forwarding message: #{inspect RiemannProxy.Proto.Msg.decode(data)}") end)
+    # spawn(fn -> nil end)
+    # spawn(fn -> RiemannProxy.Router.fake_route(data) end)
+    RiemannProxy.Router.route(data, 1)
+    ok_msg
+  end
+
+  def ok_msg do
     RiemannProxy.Proto.Msg.encode(RiemannProxy.Proto.Msg.new(ok: true))
   end
 

--- a/lib/riemann_proxy/server.ex
+++ b/lib/riemann_proxy/server.ex
@@ -23,7 +23,8 @@ defmodule RiemannProxy.Server do
 
   defp read_line(socket) do
     {:ok, data} = :gen_tcp.recv(socket, 0)
-    IO.puts "Recv: #{inspect data, limit: 50}"
+    IO.puts "Forwarding message: #{inspect RiemannProxy.Proto.Msg.decode(data)}"
+    RiemannProxy.Router.fake_route(data)
     RiemannProxy.Proto.Msg.encode(RiemannProxy.Proto.Msg.new(ok: true))
   end
 

--- a/router.txt
+++ b/router.txt
@@ -1,0 +1,26 @@
+Mnesia schema:
+
+Routes:
+  service   host  endpoints
+  test.*    *     a
+  tost.*    *     b
+
+Endpoints (Ring like):
+  ids   host  port  transport
+  1     a.com 5555  tcp
+  2     b.com 5555  tcp
+  3     c.com 5555  tcp
+
+  If 1 fails, fallback to 2.
+  If 2 fails, fallback to 3.
+  If 3 fails, fallback to 1.
+  ...
+  If 1 and 2 fail, fallback to 3.
+
+Statistics:
+  * bytes sent to each endpoint
+
+Journal:
+  * up / down endpoints
+
+Honeydew TCP pool?

--- a/router.txt
+++ b/router.txt
@@ -1,9 +1,12 @@
 Mnesia schema:
 
 Routes:
-  service   host  endpoints
-  test.*    *     a
-  tost.*    *     b
+  tagged  service   host  endpoints
+  foo     *         *     a
+  *       test.*    *     b
+  *       tost.*    *     c
+
+  *       *         *     a
 
 Endpoints (Ring like):
   ids   host  port  transport


### PR DESCRIPTION
@edelpero take a loOK on this bro, by running RiemannProxy.Router.start_link, it spins up an EndpointWatcher, which first prefills a local, in-memory Mnesia table 'endpoint_dispatchers' with {endpoint_idx, endpoint_dispatcher_pid}, and then subscribes to Mnesia events on the 'endpoints' table, to automatically spawn new EndpointDispatchers when a new endpoint record is written.
Whenever the Server receives a message, by now it is doing a dumb forward to the endpoint_dispatcher with idx=1 (see lib/riemann_proxy/server.ex on line #29). In a next iteration we will add the routing logic.
